### PR TITLE
Add files via upload

### DIFF
--- a/Bottoms.html
+++ b/Bottoms.html
@@ -103,10 +103,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-1">
-            <img class="img-thumbnail" src="OscardelaRenta/OD11Front1080.png" onmouseover="this.src='OscardelaRenta/OD11Back1080.png'" onmouseout="this.src='OscardelaRenta/OD11Front1080.png'">
+            <img class="img-thumbnail" src="OD11Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-1">
-            <img class="img-thumbnail" src="OscardelaRenta/OD11FrontLg.png" onmouseover="this.src='OscardelaRenta/OD11BackLg.png'" onmouseout="this.src='OscardelaRenta/OD11FrontLg.png'">
+            <img class="img-thumbnail" src="OD11BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -120,10 +120,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-2">
-            <img class="img-thumbnail" src="Escada/E3Front1080.png" onmouseover="this.src='Escada/E3Back1080.png'" onmouseout="this.src='Escada/E3Front1080.png'">
+            <img class="img-thumbnail" src="Escada/E3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-2">
-            <img class="img-thumbnail" src="Escada/E3FrontLg.png" onmouseover="this.src='Escada/E3BackLg.png'" onmouseout="this.src='Escada/E3FrontLg.png'">
+            <img class="img-thumbnail" src="Escada/E3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -137,10 +137,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-3">
-            <img class="img-thumbnail" src="GemmaKahng/GKFront1080.png" onmouseover="this.src='GemmaKahng/GKBack1080.png'" onmouseout="this.src='GemmaKahng/GKFront1080.png'">
+            <img class="img-thumbnail" src="GemmaKahng/GKFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-3">
-            <img class="img-thumbnail" src="GemmaKahng/GKFrontLg.png" onmouseover="this.src='GemmaKahng/GKBackLg.png'" onmouseout="this.src='GemmaKahng/GKFrontLg.png'">
+            <img class="img-thumbnail" src="GemmaKahng/GKBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -154,10 +154,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-4">
-            <img class="img-thumbnail" src="Mugler/TM5Front1080.png" onmouseover="this.src='Mugler/TM5Back1080.png'" onmouseout="this.src='Mugler/TM5Front1080.png'">
+            <img class="img-thumbnail" src="Mugler/TM5Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-4">
-            <img class="img-thumbnail" src="Mugler/TM5FrontLg.png" onmouseover="this.src='Mugler/TM5BackLg.png'" onmouseout="this.src='Mugler/TM5FrontLg.png'">
+            <img class="img-thumbnail" src="Mugler/TM5BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -171,10 +171,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-5">
-            <img class="img-thumbnail" src="Yeohlee/Y1Front1080.png" onmouseover="this.src='Yeohlee/Y1Front1080.png'" onmouseout="this.src='Yeohlee/Y1Front1080.png'">
+            <img class="img-thumbnail" src="Yeohlee/Y1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-5">
-            <img class="img-thumbnail" src="Yeohlee/Y1FrontLg.png" onmouseover="this.src='Yeohlee/Y1FrontLg.png'" onmouseout="this.src='Yeohlee/Y1FrontLg.png'">
+            <img class="img-thumbnail" src="Yeohlee/Y1FrontLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -188,10 +188,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-6">
-            <img class="img-thumbnail" src="Valentino/V4Front1080.png" onmouseover="this.src='Valentino/V4Back1080.png'" onmouseout="this.src='Valentino/V4Front1080.png'">
+            <img class="img-thumbnail" src="Valentino/V4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-6">
-            <img class="img-thumbnail" src="Valentino/V4FrontLg.png" onmouseover="this.src='Valentino/V4BackLg.png'" onmouseout="this.src='Valentino/V4FrontLg.png'">
+            <img class="img-thumbnail" src="Valentino/V4BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -205,10 +205,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-7">
-            <img class="img-thumbnail" src="Escada/E4Front1080.png" onmouseover="this.src='Escada/E4Back1080.png'" onmouseout="this.src='Escada/E4Front1080.png'">
+            <img class="img-thumbnail" src="Escada/E4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-7">
-            <img class="img-thumbnail" src="Escada/E4FrontLg.png" onmouseover="this.src='Escada/E4BackLg.png'" onmouseout="this.src='Escada/E4FrontLg.png'">
+            <img class="img-thumbnail" src="Escada/E4BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -222,10 +222,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-8">
-            <img class="img-thumbnail" src="JeanPaulGautier/JPGFront1080.png" onmouseover="this.src='JeanPaulGautier/JPGBack1080.png'" onmouseout="this.src='JeanPaulGautier/JPGFront1080.png'">
+            <img class="img-thumbnail" src="JeanPaulGautier/JPGFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-8">
-            <img class="img-thumbnail" src="JeanPaulGautier/JPGFrontLg.png" onmouseover="this.src='JeanPaulGautier/JPGBackLg.png'" onmouseout="this.src='JeanPaulGautier/JPGFrontLg.png'">
+            <img class="img-thumbnail" src="JeanPaulGautier/JPGBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -239,10 +239,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-9">
-            <img class="img-thumbnail" src="OscardelaRenta/OD12Front1080.png" onmouseover="this.src='OscardelaRenta/OD12Back1080.png'" onmouseout="this.src='OscardelaRenta/OD12Front1080.png'">
+            <img class="img-thumbnail" src="OD12Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-9">
-            <img class="img-thumbnail" src="OscardelaRenta/OD12FrontLg.png" onmouseover="this.src='OscardelaRenta/OD12BackLg.png'" onmouseout="this.src='OscardelaRenta/OD12FrontLg.png'">
+            <img class="img-thumbnail" src="OD12BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -256,10 +256,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-10">
-            <img class="img-thumbnail" src="OscardelaRenta/OD13Front1080.png" onmouseover="this.src='OscardelaRenta/OD13Back1080.png'" onmouseout="this.src='OscardelaRenta/OD13Front1080.png'">
+            <img class="img-thumbnail" src="OD13Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-10">
-            <img class="img-thumbnail" src="OscardelaRenta/OD13FrontLg.png" onmouseover="this.src='OscardelaRenta/OD13BackLg.png'" onmouseout="this.src='OscardelaRenta/OD13FrontLg.png'">
+            <img class="img-thumbnail" src="OD13BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -273,10 +273,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#bottom-11">
-            <img class="img-thumbnail" src="JohnGalliano/JGFront1080.png" onmouseover="this.src='JohnGalliano/JGBack1080.png'" onmouseout="this.src='JohnGalliano/JGFront1080.png'">
+            <img class="img-thumbnail" src="JohnGalliano/JGFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="bottom-11">
-            <img class="img-thumbnail" src="JohnGalliano/JGFrontLg.png" onmouseover="this.src='JohnGalliano/JGBackLg.png'" onmouseout="this.src='JohnGalliano/JGFrontLg.png'">
+            <img class="img-thumbnail" src="JohnGalliano/JGBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">

--- a/Gowns.html
+++ b/Gowns.html
@@ -102,10 +102,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-8">
-            <img class="img-thumbnail" src="Mugler/TMFront1080.png" onmouseover="this.src='Mugler/TMBack1080.png'" onmouseout="this.src='Mugler/TMFront1080.png'">
+            <img class="img-thumbnail" src="Mugler/TMFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-8">
-            <img class="img-fluid" src="Mugler/TMFrontLg.png" onmouseover="this.src='Mugler/TMBackLg.png'" onmouseout="this.src='Mugler/TMFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="Mugler/TMBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -119,10 +119,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-5">
-            <img class="img-thumbnail" src="Galanos/GNFront1080.png" onmouseover="this.src='Galanos/GNBack1080.png'" onmouseout="this.src='Galanos/GNFront1080.png'">
+            <img class="img-thumbnail" src="Galanos/GNFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-5">
-            <img class="img-fluid" src="Galanos/GNFrontLg.png" onmouseover="this.src='Galanos/GNBackLg.png'" onmouseout="this.src='Galanos/GNFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="Galanos/GNBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -136,10 +136,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-23">
-            <img class="img-thumbnail" src="ChristianDior/CDFront1080.png" onmouseover="this.src='ChristianDior/CDBack1080.png'" onmouseout="this.src='ChristianDior/CDFront1080.png'">
+            <img class="img-thumbnail" src="ChristianDior/CDFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-23">
-            <img class="img-fluid" src="ChristianDior/CDFrontLg.png" onmouseover="this.src='ChristianDior/CDLabel.jpg'" onmouseout="this.src='ChristianDior/CDFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="ChristianDior/CDBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -153,10 +153,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-27">
-            <img class="img-thumbnail" src="Valentino/VFront1080.png" onmouseover="this.src='Valentino/VBack1080.png'" onmouseout="this.src='Valentino/VFront1080.png'">
+            <img class="img-thumbnail" src="Valentino/VFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-27">
-            <img class="img-fluid" src="Valentino/VFrontLg.png" onmouseover="this.src='Valentino/VLabel.png'" onmouseout="this.src='Valentino/VFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="Valentino/VBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -170,10 +170,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-30">
-            <img class="img-thumbnail" src="RenaLange/RLFront1080.png" onmouseover="this.src='RenaLange/RLBack1080.png'" onmouseout="this.src='RenaLange/RLFront1080.png'">
+            <img class="img-thumbnail" src="RenaLange/RLFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-30">
-            <img class="img-fluid" src="RenaLange/RLFrontLg.png" onmouseover="this.src='RenaLange/RLBackLg.png'" onmouseout="this.src='RenaLange/RLFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="RenaLange/RLBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -187,10 +187,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-29">
-            <img class="img-thumbnail" src="JacquesFath/JF5Front1080.png" onmouseover="this.src='JacquesFath/JF5Back1080.png'" onmouseout="this.src='JacquesFath/JF5Front1080.png'">
+            <img class="img-thumbnail" src="JacquesFath/JF5Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-29">
-            <img class="img-fluid" src="JacquesFath/JF5FrontLg.png" onmouseover="this.src='JacquesFath/JF5BackLg.png'" onmouseout="this.src='JacquesFath/JF5FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="JacquesFath/JF5BackLg.png">"
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -204,10 +204,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-22">
-            <img class="img-thumbnail" src="AmyMichelson/AMFront1080.png" onmouseover="this.src='AmyMichelson/AMBack1080.png'" onmouseout="this.src='AmyMichelson/AMFront1080.png'">
+            <img class="img-thumbnail" src="AmyMichelson/AMFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-22">
-            <img class="img-fluid" src="AmyMichelson/AMFrontLg.png" onmouseover="this.src='AmyMichelson/AMBackLg.png'" onmouseout="this.src='AmyMichelson/AMFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="AmyMichelson/AMBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -221,10 +221,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-15">
-            <img class="img-thumbnail" src="DanWerle/DWFront1080.png" onmouseover="this.src='DanWerle/DWBack1080.png'" onmouseout="this.src='DanWerle/DWFront1080.png'">
+            <img class="img-thumbnail" src="DanWerle/DWFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-15">
-            <img class="img-fluid" src="DanWerle/DWFrontLg.png" onmouseover="this.src='DanWerle/DWBackLg.png'" onmouseout="this.src='DanWerle/DWFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="DanWerle/DWBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -238,10 +238,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-10">
-            <img class="img-thumbnail" src="MaryMcFadden/MMFront1080.png" onmouseover="this.src='MaryMcFadden/MMBack1080.png'" onmouseout="this.src='MaryMcFadden/MMFront1080.png'">
+            <img class="img-thumbnail" src="MMFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-10">
-            <img class="img-fluid" src="MaryMcFadden/MMFrontLg.png" onmouseover="this.src='MaryMcFadden/MMBackLg.png'" onmouseout="this.src='MaryMcFadden/MMFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="MMBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -255,10 +255,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-7">
-            <img class="img-thumbnail" src="VickyTiel/VTFront1080.png" onmouseover="this.src='VickyTiel/VTBack1080.png'" onmouseout="this.src='VickyTiel/VTFront1080.png'">
+            <img class="img-thumbnail" src="VickyTiel/VTFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-7">
-            <img class="img-fluid" src="VickyTiel/VTFrontLg.png" onmouseover="this.src='VickyTiel/VTBackLg.png'" onmouseout="this.src='VickyTiel/VTFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="VickyTiel/VTBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -272,10 +272,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-2">
-            <img class="img-thumbnail" src="AnnLawrence/ALFront1080.png" onmouseover="this.src='AnnLawrence/ALBack1080.png'" onmouseout="this.src='AnnLawrence/ALFront1080.png'">
+            <img class="img-thumbnail" src="AnnLawrence/ALFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-2">
-            <img class="img-fluid" src="AnnLawrence/ALFrontLg.png" onmouseover="this.src='AnnLawrence/ALBackLg.png'" onmouseout="this.src='AnnLawrence/ALFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="AnnLawrence/ALBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -289,10 +289,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-3">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD1Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD1Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD1Front1080.png'">
+            <img class="img-thumbnail" src="OscarDeLaRenta/OD1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-3">
-            <img class="img-fluid" src="OscarDeLaRenta/OD1FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD1BackLg.png'" onmouseout="this.src='OscarDeLaRenta/OD1Label.jpg'" alt="TS-Pic"/>
+            <img class="img-fluid" src="OscarDeLaRenta/OD1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -307,10 +307,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-4">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD2Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD2Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD2Front1080.png'">
+            <img class="img-thumbnail" src="OscarDeLaRenta/OD2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-4">
-            <img class="img-fluid" src="OscarDeLaRenta/OD2FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD2BackLg.png'" onmouseout="this.src='OscarDeLaRenta/OD2FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="OscarDeLaRenta/OD2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -324,10 +324,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-12">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD3Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD3Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD3Front1080.png'">
+            <img class="img-thumbnail" src="OscarDeLaRenta/OD3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-12">
-            <img class="img-fluid" src="OscarDeLaRenta/OD3FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD3Detail.png'" onmouseout="this.src='OscarDeLaRenta/OD3BackLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="OscarDeLaRenta/OD3Detail.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -341,10 +341,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-9">
-            <img class="img-thumbnail" src="BadgleyMischka/BGM1Front1080.png" onmouseover="this.src='BadgleyMischka/BGM1Back1080.png'" onmouseout="this.src='BadgleyMischka/BGM1Front1080.png'">
+            <img class="img-thumbnail" src="BadgleyMischka/BGM1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-9">
-            <img class="img-fluid" src="BadgleyMischka/BGM1FrontLg.png" onmouseover="this.src='BadgleyMischka/BGM1BackLg.png'" onmouseout="this.src='BadgleyMischka/BGM1FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="BadgleyMischka/BGM1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -358,10 +358,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-11">
-            <img class="img-thumbnail" src="RichardTyler/RTFront1080.png" onmouseover="this.src='RichardTyler/RTBack1080.png'" onmouseout="this.src='RichardTyler/RTFront1080.png'">
+            <img class="img-thumbnail" src="RichardTyler/RTFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-11">
-            <img class="img-fluid" src="RichardTyler/RTFrontLg.png" onmouseover="this.src='RichardTyler/RTBackLg.png'" onmouseout="this.src='RichardTyler/RTFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="RichardTyler/RTBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -375,10 +375,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-28">
-            <img class="img-thumbnail" src="SophieSitbon/SS1Front1080.png" onmouseover="this.src='SophieSitbon/SS1Back1080.png'" onmouseout="this.src='SophieSitbon/SS1Front1080.png'">
+            <img class="img-thumbnail" src="SophieSitbon/SS1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-28">
-            <img class="img-fluid" src="SophieSitbon/SS1FrontLg.png" onmouseover="this.src='SophieSitbon/SS1BackLg.png'" onmouseout="this.src='SophieSitbon/SS1FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="SophieSitbon/SS1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -392,10 +392,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-6">
-            <img class="img-thumbnail" src="BobMackie/BMFront1080.png" onmouseover="this.src='BobMackie/BMBack1080.png'" onmouseout="this.src='BobMackie/BMFront1080.png'">
+            <img class="img-thumbnail" src="BobMackie/BMFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-6">
-            <img class="img-fluid" src="BobMackie/BMFrontLg.png" onmouseover="this.src='BobMackie/BMBackLg.png'" onmouseout="this.src='BobMackie/BMFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="BobMackie/BMBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -409,10 +409,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-13">
-            <img class="img-thumbnail" src="BadgleyMischka/BGM2Front1080.png" onmouseover="this.src='BadgleyMischka/BGM2Back1080.png'" onmouseout="this.src='BadgleyMischka/BGM2Front1080.png'">
+            <img class="img-thumbnail" src="BadgleyMischka/BGM2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-13">
-            <img class="img-fluid" src="BadgleyMischka/BGM2FrontLg.png" onmouseover="this.src='BadgleyMischka/BGM2BackLg.png'" onmouseout="this.src='BadgleyMischka/BGM2FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="BadgleyMischka/BGM2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -427,10 +427,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-14">
-            <img class="img-thumbnail" src="JacquesFath/JFFront1080.png" onmouseover="this.src='JacquesFath/JFBack1080.png'" onmouseout="this.src='JacquesFath/JFFront1080.png'">
+            <img class="img-thumbnail" src="JacquesFath/JFFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-14">
-            <img class="img-fluid" src="JacquesFath/JFFrontLg.png" onmouseover="this.src='JacquesFath/JFBackLg.png'" onmouseout="this.src='JacquesFath/JFFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="JacquesFath/JFBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -444,10 +444,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-16">
-            <img class="img-thumbnail" src="JamesPurcell/JPFront1080.png" onmouseover="this.src='JamesPurcell/JPBack1080.png'" onmouseout="this.src='JamesPurcell/JPFront1080.png'">
+            <img class="img-thumbnail" src="JamesPurcell/JPFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-16">
-            <img class="img-fluid" src="JamesPurcell/JPFrontLg.png" onmouseover="this.src='JamesPurcell/JPBackLg.png'" onmouseout="this.src='JamesPurcell/JPFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="JamesPurcell/JPBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -461,10 +461,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-17">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD4Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD4Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD4Front1080.png'">
+            <img class="img-thumbnail" src="OscarDeLaRenta/OD4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-17">
-            <img class="img-fluid" src="OscarDeLaRenta/OD4FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD4BackLg.png'" onmouseout="this.src='OscarDeLaRenta/OD4FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="OscarDeLaRenta/OD4BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -478,10 +478,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-18">
-            <img class="img-thumbnail" src="MichaelCasey/MCFront1080.png" onmouseover="this.src='MichaelCasey/MCBack1080.png'" onmouseout="this.src='MichaelCasey/MCFront1080.png'">
+            <img class="img-thumbnail" src="MichaelCasey/MCFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-18">
-            <img class="img-fluid" src="MichaelCasey/MCFrontLg.png" onmouseover="this.src='MichaelCasey/MCBackLg.png'" onmouseout="this.src='MichaelCasey/MCFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="MichaelCasey/MCBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -495,14 +495,14 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-24">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD5Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD5Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD5Front1080.png'">
+            <img class="img-thumbnail" src="OscarDeLaRenta/OD5Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-24">
-            <img class="img-fluid" src="OscarDeLaRenta/OD5FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD5BackLg.png'" onmouseout="this.src='OscarDeLaRenta/OD5FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="OscarDeLaRenta/OD5BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
-          <p class="brandname">Oscar de la Renta</p>
+          <p class="brandname">Heidi Weisel</p>
           <!-- <p class="itemname">Size 8</p>  -->
         </div> 
       </div>    
@@ -512,10 +512,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-20">
-            <img class="img-thumbnail" src="JacquesFath/JF1Front1080.png" onmouseover="this.src='JacquesFath/JF1Back1080.png'" onmouseout="this.src='JacquesFath/JF1Front1080.png'">
+            <img class="img-thumbnail" src="JacquesFath/JF1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-20">
-            <img class="img-fluid" src="JacquesFath/JF1FrontLg.png" onmouseover="this.src='JacquesFath/JF1BackLg.png'" onmouseout="this.src='JacquesFath/JF1FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="JacquesFath/JF1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -529,10 +529,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-19">
-            <img class="img-thumbnail" src="MichaelCasey/MC1Front1080.png" onmouseover="this.src='MichaelCasey/MC1Back1080.png'" onmouseout="this.src='MichaelCasey/MC1Front1080.png'">
+            <img class="img-thumbnail" src="MichaelCasey/MC1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-19">
-            <img class="img-fluid" src="MichaelCasey/MC1FrontLg.png" onmouseover="this.src='MichaelCasey/MC1BackLg.png'" onmouseout="this.src='MichaelCasey/MC1FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="MichaelCasey/MC1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -546,10 +546,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-21">
-            <img class="img-thumbnail" src="JacquesFath/JF2Front1080.png" onmouseover="this.src='JacquesFath/JF2Back1080.png'" onmouseout="this.src='JacquesFath/JF2Front1080.png'">
+            <img class="img-thumbnail" src="JacquesFath/JF2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-21">
-            <img class="img-fluid" src="JacquesFath/JF2FrontLg.png" onmouseover="this.src='JacquesFath/JF2BackLg.png'" onmouseout="this.src='JacquesFath/JF2FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="JacquesFath/JF2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -563,10 +563,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-25">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD6Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD6Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD6Front1080.png'">
+            <img class="img-thumbnail" src="OscarDeLaRenta/OD6Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-25">
-            <img class="img-fluid" src="OscarDeLaRenta/OD6FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD6BackLg.png'" onmouseout="this.src='OscarDeLaRenta/OD6FrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="OscarDeLaRenta/OD6BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -580,10 +580,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#gown-26">
-            <img class="img-thumbnail" src="PatriciaRhodes/PRFront1080.png" onmouseover="this.src='PatriciaRhodes/PRBack1080.png'" onmouseout="this.src='PatriciaRhodes/PRFront1080.png'">
+            <img class="img-thumbnail" src="PatriciaRhodes/PRFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-26">
-            <img class="img-fluid" src="PatriciaRhodes/PRFrontLg.png" onmouseover="this.src='PatriciaRhodes/PRBackLg.png'" onmouseout="this.src='PatriciaRhodes/PRFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="PatriciaRhodes/PRBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -597,10 +597,10 @@
     <div class="col-lg-4 col-sm-6">
       <div class="lb-album">
           <a href="#gown-1">
-            <img class="img-thumbnail" src="TomaszStarzewski/TSFront1080.png" onmouseover="this.src='TomaszStarzewski/TSBack1080.png'" onmouseout="this.src='TomaszStarzewski/TSFront1080.png'">
+            <img class="img-thumbnail" src="TomaszStarzewski/TSFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="gown-1">
-            <img class="img-fluid" src="TomaszStarzewski/TSFrontLg.png" onmouseover="this.src='TomaszStarzewski/TSBackLg.png'" onmouseout="this.src='TomaszStarzewski/TSFrontLg.png'" alt="TS-Pic"/>
+            <img class="img-fluid" src="TomaszStarzewski/TSBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">

--- a/JacketsAndOuterwear.html
+++ b/JacketsAndOuterwear.html
@@ -16,7 +16,7 @@
 
     <link rel="stylesheet" type="text/css" href="BESAHaum.css">
 
-    <link rel="stylesheet" type="text/css" href="BESAHome.js">
+    <link rel="stylesheet" type="text/css" href="Collection.js">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Playfair+Display+SC" rel="stylesheet">
@@ -103,10 +103,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-26">
-            <img class="img-thumbnail" src="RomeoGigli/RGFront1080.png" onmouseover="this.src='RomeoGigli/RGBack1080.png'" onmouseout="this.src='RomeoGigli/RGFront1080.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RGFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-26">
-            <img class="img-thumbnail" src="RomeoGigli/RGFrontLg.png" onmouseover="this.src='RomeoGigli/RGBackLg.png'" onmouseout="this.src='RomeoGigli/RGFrontLg.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RGBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -120,10 +120,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-27">
-            <img class="img-thumbnail" src="PilarRossi/PRIFront1080.png" onmouseover="this.src='PilarRossi/PRIBack1080.png'" onmouseout="this.src='PilarRossi/PRIFront1080.png'">
+            <img class="img-thumbnail" src="PilarRossi/PRIFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-27">
-            <img class="img-thumbnail" src="PilarRossi/PRIFrontLg.png" onmouseover="this.src='PilarRossi/PRIBackLg.png'" onmouseout="this.src='PilarRossi/PRIFrontLg.png'">
+            <img class="img-thumbnail" src="PilarRossi/PRIBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -137,10 +137,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-29">
-            <img class="img-thumbnail" src="Mugler/TM1Front1080.png" onmouseover="this.src='Mugler/TM1Back1080.png'" onmouseout="this.src='Mugler/TM1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-29">
-            <img class="img-thumbnail" src="Mugler/TM1FrontBlkLg.png" onmouseover="this.src='Mugler/TM1BackBlkLg.png'" onmouseout="this.src='Mugler/TM1FrontBlkLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM1BackBlkLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -154,10 +154,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-30">
-            <img class="img-thumbnail" src="Unknown/UKN1Front1080.png" onmouseover="this.src='Unknown/UKN1Back1080.png'" onmouseout="this.src='Unknown/UKN1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Unknown/UKN1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-30">
-            <img class="img-thumbnail" src="Unknown/UKN1FrontBlkLg.png" onmouseover="this.src='Unknown/UKN1BackBlkLg.png'" onmouseout="this.src='Unknown/UKN1FrontBlkLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Unknown/UKN1BackBlkLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -171,10 +171,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-44">
-            <img class="img-thumbnail" src="Galanos/GN1Front1080.png" onmouseover="this.src='Galanos/GN1Back1080.png'" onmouseout="this.src='Galanos/GN1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Galanos/GN1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-44">
-            <img class="img-thumbnail" src="Galanos/GN1FrontLg.png" onmouseover="this.src='Galanos/GN1BackLg.png'" onmouseout="this.src='Galanos/GN1FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Galanos/GN1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -188,10 +188,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-32">
-            <img class="img-thumbnail" src="BadgleyMischka/BGM4Front1080.png" onmouseover="this.src='BadgleyMischka/BGM4Back1080.png'" onmouseout="this.src='BadgleyMischka/BGM4Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="BadgleyMischka/BGM4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-32">
-            <img class="img-thumbnail" src="BadgleyMischka/BGM4FrontLg.png" onmouseover="this.src='BadgleyMischka/BGM4BackLg.png'" onmouseout="this.src='BadgleyMischka/BGM4FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="BadgleyMischka/BGM4BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -205,10 +205,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-34">
-            <img class="img-thumbnail" src="Yeohlee/YFront1080.png" onmouseover="this.src='Yeohlee/YBack1080.png'" onmouseout="this.src='Yeohlee/YFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Yeohlee/YFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-34">
-            <img class="img-thumbnail" src="Yeohlee/YFrontLg.png" onmouseover="this.src='Yeohlee/YBackLg.png'" onmouseout="this.src='Yeohlee/YFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Yeohlee/YBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -222,10 +222,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-31">
-            <img class="img-thumbnail" src="PaulineTrigere/PTFront1080.png" onmouseover="this.src='PaulineTrigere/PTBack1080.png'" onmouseout="this.src='PaulineTrigere/PTFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="PaulineTrigere/PTFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-31">
-            <img class="img-thumbnail" src="PaulineTrigere/PTFrontLg.png" onmouseover="this.src='PaulineTrigere/PTBackLg.png'" onmouseout="this.src='PaulineTrigere/PTFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="PaulineTrigere/PTBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -239,10 +239,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-35">
-            <img class="img-thumbnail" src="Mugler/TM2Front1080.png" onmouseover="this.src='Mugler/TM2Back1080.png'" onmouseout="this.src='Mugler/TM2Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-35">
-            <img class="img-thumbnail" src="Mugler/TM2FrontLg.png" onmouseover="this.src='Mugler/TM2BackLg.png'" onmouseout="this.src='Mugler/TM2FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -256,10 +256,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-39">
-            <img class="img-thumbnail" src="Escada/E1Front1080.png" onmouseover="this.src='Escada/E1Back1080.png'" onmouseout="this.src='Escada/E1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Escada/E1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-39">
-            <img class="img-fluid" src="Escada/E1FrontLg.png" onmouseover="this.src='Escada/E1BackLg.png'" onmouseout="this.src='Escada/E1FrontLg.png'" alt="TS-Pic"/>
+            <img class="scrollingPanel img-fluid" src="Escada/E1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -273,10 +273,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-42">
-            <img class="img-thumbnail" src="Mugler/TM4Front1080.png" onmouseover="this.src='Mugler/TM4Back1080.png'" onmouseout="this.src='Mugler/TM4Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-42">
-            <img class="img-thumbnail" src="Mugler/TM4FrontLg.png" onmouseover="this.src='Mugler/TM4BackLg.png'" onmouseout="this.src='Mugler/TM4FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM4BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -290,10 +290,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-13">
-            <img class="img-thumbnail" src="EmanuelUngaro/EUFront1080.png" onmouseover="this.src='EmanuelUngaro/EUBack1080.png'" onmouseout="this.src='EmanuelUngaro/EUFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="EmanuelUngaro/EUFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-13">
-            <img class="img-fluid" src="EmanuelUngaro/EUFrontLg.png" onmouseover="this.src='EmanuelUngaro/EUBackLg.png'" onmouseout="this.src='EmanuelUngaro/EUFrontLg.png'" alt="TS-Pic"/>
+            <img class="scrollingPanel img-fluid" src="EmanuelUngaro/EUBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -307,10 +307,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-14">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD7Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD7Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD7Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="OscarDeLaRenta/OD7Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-14">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD7FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD7BackLg.png'" onmouseout="this.src='OscarDeLaRenta/OD7FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="OscarDeLaRenta/OD7BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -324,10 +324,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-16">
-            <img class="img-thumbnail" src="DolceGabbana/DGFront1080.png" onmouseover="this.src='DolceGabbana/DGBack1080.png'" onmouseout="this.src='DolceGabbana/DGFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="DolceGabbana/DGFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-16">
-            <img class="img-thumbnail" src="DolceGabbana/DGFrontLg.png" onmouseover="this.src='DolceGabbana/DGBackLg.png'" onmouseout="this.src='DolceGabbana/DGFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="DolceGabbana/DGBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -341,10 +341,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-17">
-            <img class="img-thumbnail" src="Valentino/V1Front1080.png" onmouseover="this.src='Valentino/V1Back1080.png'" onmouseout="this.src='Valentino/V1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Valentino/V1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-17">
-            <img class="img-thumbnail" src="Valentino/V1FrontLg.png" onmouseover="this.src='Valentino/V1BackLg.png'" onmouseout="this.src='Valentino/V1FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Valentino/V1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -358,10 +358,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-18">
-            <img class="img-thumbnail" src="EmanuelUngaro/EU1Front1080.png" onmouseover="this.src='EmanuelUngaro/EU1Back1080.png'" onmouseout="this.src='EmanuelUngaro/EU1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="EmanuelUngaro/EU1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-18">
-            <img class="img-thumbnail" src="EmanuelUngaro/EU1FrontLg.png" onmouseover="this.src='EmanuelUngaro/EU1BackLg.png'" onmouseout="this.src='EmanuelUngaro/EU1FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="EmanuelUngaro/EU1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -375,10 +375,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-19">
-            <img class="img-thumbnail" src="Balenciaga/BFront1080.png" onmouseover="this.src='Balenciaga/BBack1080.png'" onmouseout="this.src='Balenciaga/BFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Balenciaga/BFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-19">
-            <img class="img-thumbnail" src="Balenciaga/BFrontLg.png" onmouseover="this.src='Balenciaga/BBackLg.png'" onmouseout="this.src='Balenciaga/BFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Balenciaga/BBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -392,10 +392,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-20">
-            <img class="img-thumbnail" src="CarolyneRoehm/CRFront1080.png" onmouseover="this.src='CarolyneRoehm/CRBack1080.png'" onmouseout="this.src='CarolyneRoehm/CRFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="CarolyneRoehm/CRFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-20">
-            <img class="img-thumbnail" src="CarolyneRoehm/CRFrontLg.png" onmouseover="this.src='CarolyneRoehm/CRBackLg.png'" onmouseout="this.src='CarolyneRoehm/CRFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="CarolyneRoehm/CRBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -409,10 +409,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-21">
-            <img class="img-thumbnail" src="GeoffreyBeene/GBFront1080.png" onmouseover="this.src='GeoffreyBeene/GBBack1080.png'" onmouseout="this.src='GeoffreyBeene/GBFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="GeoffreyBeene/GBFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-21">
-            <img class="img-thumbnail" src="GeoffreyBeene/GBFrontLg.png" onmouseover="this.src='GeoffreyBeene/GBBackLg.png'" onmouseout="this.src='GeoffreyBeene/GBFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="GeoffreyBeene/GBBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -426,10 +426,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-22">
-            <img class="img-thumbnail" src="GianfrancoFerre/GFFront1080.png" onmouseover="this.src='GianfrancoFerre/GFBack1080.png'" onmouseout="this.src='GianfrancoFerre/GFFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="GianfrancoFerre/GFFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-22">
-            <img class="img-thumbnail" src="GianfrancoFerre/GFFrontLg.png" onmouseover="this.src='GianfrancoFerre/GFBackLg.png'" onmouseout="this.src='GianfrancoFerre/GFFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="GianfrancoFerre/GFBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -443,10 +443,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-23">
-            <img class="img-thumbnail" src="JillSander/JSFront1080.png" onmouseover="this.src='JillSander/JSBack1080.png'" onmouseout="this.src='JillSander/JSFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="JillSander/JSFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-23">
-            <img class="img-thumbnail" src="JillSander/JSFrontLg.png" onmouseover="this.src='JillSander/JSBackLg.png'" onmouseout="this.src='JillSander/JSFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="JillSander/JSBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -460,10 +460,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-24">
-            <img class="img-thumbnail" src="MaryMcFadden/MM1Front1080.png" onmouseover="this.src='MaryMcFadden/MM1Back1080.png'" onmouseout="this.src='MaryMcFadden/MM1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="MM1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-24">
-            <img class="img-thumbnail" src="MaryMcFadden/MM1FrontLg.png" onmouseover="this.src='MaryMcFadden/MM1BackLg.png'" onmouseout="this.src='MaryMcFadden/MM1FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="MM1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -477,10 +477,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-25">
-            <img class="img-thumbnail" src="Montana/MTFront1080.png" onmouseover="this.src='Montana/MTBack1080.png'" onmouseout="this.src='Montana/MTFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Montana/MTFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-25">
-            <img class="img-thumbnail" src="Montana/MTFrontLg.png" onmouseover="this.src='Montana/MTBackLg.png'" onmouseout="this.src='Montana/MTFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Montana/MTBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -494,10 +494,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-15">
-            <img class="img-thumbnail" src="JacquesFath/JF3Front1080.png" onmouseover="this.src='JacquesFath/JF3Back1080.png'" onmouseout="this.src='JacquesFath/JF3Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="JacquesFath/JF3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-15">
-            <img class="img-thumbnail" src="JacquesFath/JF3FrontLg.png" onmouseover="this.src='JacquesFath/JF3BackLg.png'" onmouseout="this.src='JacquesFath/JF3FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="JacquesFath/JF3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -511,10 +511,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-33">
-            <img class="img-thumbnail" src="RichardTyler/RT6Front1080.png" onmouseover="this.src='RichardTyler/RT6Back1080.png'" onmouseout="this.src='RichardTyler/RT6Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="RichardTyler/RT6Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-33">
-            <img class="img-thumbnail" src="RichardTyler/RT6FrontLg.png" onmouseover="this.src='RichardTyler/RT6BackLg.png'" onmouseout="this.src='RichardTyler/RT6FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="RichardTyler/RT6BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -529,10 +529,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-36">
-            <img class="img-thumbnail" src="Mugler/TM3Front1080.png" onmouseover="this.src='Mugler/TM3Back1080.png'" onmouseout="this.src='Mugler/TM3Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-36">
-            <img class="img-thumbnail" src="Mugler/TM3FrontLg.png" onmouseover="this.src='Mugler/TM3BackLg.png'" onmouseout="this.src='Mugler/TM3FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Mugler/TM3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -546,10 +546,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-37">
-            <img class="img-thumbnail" src="LouisFeraud/LFFront1080.png" onmouseover="this.src='LouisFeraud/LFBack1080.png'" onmouseout="this.src='LouisFeraud/LFFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="LouisFeraud/LFFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-37">
-            <img class="img-thumbnail" src="LouisFeraud/LFFrontLg.png" onmouseover="this.src='LouisFeraud/LFBackLg.png'" onmouseout="this.src='LouisFeraud/LFFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="LouisFeraud/LFBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -563,10 +563,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-40">
-            <img class="img-thumbnail" src="Galle/GEFront1080.png" onmouseover="this.src='Galle/GEBack1080.png'" onmouseout="this.src='Galle/GEFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Galle/GEFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-40">
-            <img class="img-thumbnail" src="Galle/GEFrontLg.png" onmouseover="this.src='Galle/GEBackLg.png'" onmouseout="this.src='Galle/GEFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Galle/GEBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -580,10 +580,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-38">
-            <img class="img-thumbnail" src="Montana/MT1Front1080.png" onmouseover="this.src='Montana/MT1Back1080.png'" onmouseout="this.src='Montana/MT1Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Montana/MT1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-38">
-            <img class="img-thumbnail" src="Montana/MT1FrontLg.png" onmouseover="this.src='Montana/MT1BackLg.png'" onmouseout="this.src='Montana/MT1FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Montana/MT1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -597,10 +597,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-41">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD8Front1080.png" onmouseover="this.src='OscarDeLaRenta/OD8Back1080.png'" onmouseout="this.src='OscarDeLaRenta/OD8Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="OscarDeLaRenta/OD8Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-41">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OD8FrontLg.png" onmouseover="this.src='OscarDeLaRenta/OD8BackLg.png'" onmouseout="this.src='OscarDeLaRenta/OD8FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="OscarDeLaRenta/OD8BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -614,10 +614,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-43">
-            <img class="img-thumbnail" src="Unknown/UKN2Front1080.png" onmouseover="this.src='Unknown/UKN2Back1080.png'" onmouseout="this.src='Unknown/UKN2Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Unknown/UKN2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-43">
-            <img class="img-thumbnail" src="Unknown/UKN2FrontLg.png" onmouseover="this.src='Unknown/UKN2BackLg.png'" onmouseout="this.src='Unknown/UKN2FrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Unknown/UKN2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -631,10 +631,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-1">
-            <img class="img-thumbnail" src="Akris/Akris1.png" onmouseover="this.src='Akris/Akris2.png'" onmouseout="this.src='Akris/Akris1.png'">
+            <img class="scrollingPanel img-thumbnail" src="Akris/Akris1.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-1">
-            <img class="img-thumbnail" src="Akris/Akris1.png" onmouseover="this.src='Akris/Akris2.png'" onmouseout="this.src='Akris/Akris1.png'">
+            <img class="scrollingPanel img-thumbnail" src="Akris/Akris2.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -648,10 +648,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-2">
-            <img class="img-thumbnail" src="Fendi/Fendi1.png" onmouseover="this.src='Fendi/Fendi2.png'" onmouseout="this.src='Fendi/Fendi1.png'">
+            <img class="scrollingPanel img-thumbnail" src="Fendi/Fendi1.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-2">
-            <img class="img-thumbnail" src="Fendi/Fendi1.png" onmouseover="this.src='Fendi/Fendi2.png'" onmouseout="this.src='Fendi/Fendi1.png'">
+            <img class="scrollingPanel img-thumbnail" src="Fendi/Fendi2.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -665,10 +665,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-4">
-            <img class="img-thumbnail" src="Missoni/Missoni1.png" onmouseover="this.src='Missoni/Missoni2.png'" onmouseout="this.src='Missoni/Missoni1.png'">
+            <img class="scrollingPanel img-thumbnail" src="Missoni/Missoni1.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-4">
-            <img class="img-thumbnail" src="Missoni/Missoni1.png" onmouseover="this.src='Missoni/Missoni2.png'" onmouseout="this.src='Missoni/Missoni1.png'">
+            <img class="scrollingPanel img-thumbnail" src="Missoni/Missoni2.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -682,10 +682,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-5">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OscarDeLaRenta1.png" onmouseover="this.src='OscarDeLaRenta/OscarDeLaRenta2.png'" onmouseout="this.src='OscarDeLaRenta/OscarDeLaRenta1.png'">
+            <img class="scrollingPanel img-thumbnail" src="OscarDeLaRenta/OscarDeLaRenta1.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-5">
-            <img class="img-thumbnail" src="OscarDeLaRenta/OscarDeLaRenta1.png" onmouseover="this.src='OscarDeLaRenta/OscarDeLaRenta2.png'" onmouseout="this.src='OscarDeLaRenta/OscarDeLaRenta1.png'">
+            <img class="scrollingPanel img-thumbnail" src="OscarDeLaRenta/OscarDeLaRenta2.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -700,10 +700,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-6">
-            <img class="img-thumbnail" src="RichardTyler/RichardTyler1.png" onmouseover="this.src='RichardTyler/RichardTyler2.png'" onmouseout="this.src='RichardTyler/RichardTyler1.png'">
+            <img class="scrollingPanel img-thumbnail" src="RichardTyler/RichardTyler1.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-6">
-            <img class="img-thumbnail" src="RichardTyler/RichardTyler1.png" onmouseover="this.src='RichardTyler/RichardTyler2.png'" onmouseout="this.src='RichardTyler/RichardTyler1.png'">
+            <img class="scrollingPanel img-thumbnail" src="RichardTyler/RichardTyler2.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -717,10 +717,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-9">
-            <img class="img-thumbnail" src="BadgleyMischka/BGMFront1080.png" onmouseover="this.src='BadgleyMischka/BGMBack1080.png'" onmouseout="this.src='BadgleyMischka/BGMFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="BadgleyMischka/BGMFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-9">
-            <img class="img-thumbnail" src="BadgleyMischka/BGMFrontLg.png" onmouseover="this.src='BadgleyMischka/BGMBackLg.png'" onmouseout="this.src='BadgleyMischka/BGMFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="BadgleyMischka/BGMBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -734,10 +734,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-11">
-            <img class="img-thumbnail" src="BadgleyMischka/BGM3Front1080.png" onmouseover="this.src='BadgleyMischka/BGM3Back1080.png'" onmouseout="this.src='BadgleyMischka/BGM3Front1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="BadgleyMischka/BGM3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-11">
-            <img class="img-fluid" src="BadgleyMischka/BGM3FrontLg.png" onmouseover="this.src='BadgleyMischka/BGM3BackLg.png'" onmouseout="this.src='BadgleyMischka/BGM3FrontLg.png'" alt="TS-Pic"/>
+            <img class="scrollingPanel img-fluid" src="BadgleyMischka/BGM3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -751,10 +751,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-7">
-            <img class="img-thumbnail" src="Celine/CFront1080.png" onmouseover="this.src='Celine/CBack1080.png'" onmouseout="this.src='Celine/CFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Celine/CFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-7">
-            <img class="img-fluid" src="Celine/CFrontLg.png" onmouseover="this.src='Celine/CBackLg.png'" onmouseout="this.src='Celine/CFrontLg.png'" alt="TS-Pic"/>
+            <img class="scrollingPanel img-fluid" src="Celine/CBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -768,10 +768,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-8">
-            <img class="img-thumbnail" src="Fendi/FFront1080.png" onmouseover="this.src='Fendi/FBack1080.png'" onmouseout="this.src='Fendi/FFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Fendi/FFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-8">
-            <img class="img-thumbnail" src="Fendi/FFrontLg.png" onmouseover="this.src='Fendi/FBackLg.png'" onmouseout="this.src='Fendi/FFrontLg.png'">
+            <img class="scrollingPanel img-thumbnail" src="Fendi/FBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -785,10 +785,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-10">
-            <img class="img-thumbnail" src="Escada/EFront1080.png" onmouseover="this.src='Escada/EBack1080.png'" onmouseout="this.src='Escada/EFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="Escada/EFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-10">
-            <img class="img-fluid" src="Escada/EFrontLg.png" onmouseover="this.src='Escada/EDetail.png'" onmouseout="this.src='Escada/EFrontLg.png'" alt="TS-Pic"/>
+            <img class="scrollingPanel img-fluid" src="Escada/EDetail.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -802,10 +802,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-12">
-            <img class="img-thumbnail" src="SophieSitbon/SSFront1080.png" onmouseover="this.src='SophieSitbon/SSBack1080.png'" onmouseout="this.src='SophieSitbon/SSFront1080.png'">
+            <img class="scrollingPanel img-thumbnail" src="SophieSitbon/SSFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-12">
-            <img class="img-fluid" src="SophieSitbon/SSFrontLg.png" onmouseover="this.src='SophieSitbon/SSBackLg.png'" onmouseout="this.src='SophieSitbon/SSFrontLg.png'" alt="TS-Pic"/>
+            <img class="scrollingPanel img-fluid" src="SophieSitbon/SSBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -819,10 +819,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#coat-3">
-            <img class="img-thumbnail" src="JosephRibcoff/JosephR1.png" onmouseover="this.src='JosephRibcoff/JosephR2.png'" onmouseout="this.src='JosephRibcoff/JosephR1.png'">
+            <img class="scrollingPanel img-thumbnail" src="JosephRibcoff/JosephR1.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="coat-3">
-            <img class="img-thumbnail" src="JosephRibcoff/JosephR1.png" onmouseover="this.src='JosephRibcoff/JosephR2.png'" onmouseout="this.src='JosephRibcoff/JosephR1.png'">
+            <img class="scrollingPanel img-thumbnail" src="JosephRibcoff/JosephR2.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">

--- a/Tops.html
+++ b/Tops.html
@@ -103,10 +103,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-1">
-            <img class="img-thumbnail" src="AlbertaFerretti/AFFront1080.png" onmouseover="this.src='AlbertaFerretti/AFBack1080.png'" onmouseout="this.src='AlbertaFerretti/AFFront1080.png'">
+            <img class="img-thumbnail" src="AlbertaFerretti/AFFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-1">
-            <img class="img-thumbnail" src="AlbertaFerretti/AFFrontLg.png" onmouseover="this.src='AlbertaFerretti/AFBackLg.png'" onmouseout="this.src='AlbertaFerretti/AFFrontLg.png'">
+            <img class="img-thumbnail" src="AlbertaFerretti/AFBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -120,14 +120,14 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-2">
-            <img class="img-thumbnail" src="Chloe/COFront1080.png" onmouseover="this.src='Chloe/COBack1080.png'" onmouseout="this.src='Chloe/COFront1080.png'">
+            <img class="img-thumbnail" src="Chloe/COFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-2">
-            <img class="img-thumbnail" src="Chloe/COFrontLg.png" onmouseover="this.src='Chloe/COBackLg.png'" onmouseout="this.src='Chloe/COFrontLg.png'">
+            <img class="img-thumbnail" src="Chloe/COBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
-          <p class="brandname">Chloe</p>
+          <p class="brandname">Wayne Clark</p>
           <!-- <p class="itemname">Size 8</p>  -->
         </div> 
       </div>    
@@ -137,10 +137,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-3">
-            <img class="img-thumbnail" src="ChristianDior/CD1Front1080.png" onmouseover="this.src='ChristianDior/CD1Back1080.png'" onmouseout="this.src='ChristianDior/CD1Front1080.png'">
+            <img class="img-thumbnail" src="ChristianDior/CD1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-3">
-            <img class="img-thumbnail" src="ChristianDior/CD1FrontLg.png" onmouseover="this.src='ChristianDior/CD1BackLg.png'" onmouseout="this.src='ChristianDior/CD1FrontLg.png'">
+            <img class="img-thumbnail" src="ChristianDior/CD1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -154,10 +154,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-4">
-            <img class="img-thumbnail" src="RomeoGigli/RG1Front1080.png" onmouseover="this.src='RomeoGigli/RG1Back1080.png'" onmouseout="this.src='RomeoGigli/RG1Front1080.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-4">
-            <img class="img-thumbnail" src="RomeoGigli/RG1FrontLg.png" onmouseover="this.src='RomeoGigli/RG1BackLg.png'" onmouseout="this.src='RomeoGigli/RG1FrontLg.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -171,10 +171,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-5">
-            <img class="img-thumbnail" src="RichardTyler/RT7Front1080.png" onmouseover="this.src='RichardTyler/RT7Back1080.png'" onmouseout="this.src='RichardTyler/RT7Front1080.png'">
+            <img class="img-thumbnail" src="RichardTyler/RT7Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-5">
-            <img class="img-thumbnail" src="RichardTyler/RT7FrontLg.png" onmouseover="this.src='RichardTyler/RT7BackLg.png'" onmouseout="this.src='RichardTyler/RT7FrontLg.png'">
+            <img class="img-thumbnail" src="RichardTyler/RT7BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -188,10 +188,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-6">
-            <img class="img-thumbnail" src="Gucci/G2Front1080.png" onmouseover="this.src='Gucci/G2Back1080.png'" onmouseout="this.src='Gucci/G2Front1080.png'">
+            <img class="img-thumbnail" src="Gucci/G2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-6">
-            <img class="img-thumbnail" src="Gucci/G2FrontLg.png" onmouseover="this.src='Gucci/G2BackLg.png'" onmouseout="this.src='Gucci/G2FrontLg.png'">
+            <img class="img-thumbnail" src="Gucci/G2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -205,10 +205,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-7">
-            <img class="img-thumbnail" src="Givenchy/GVFront1080.png" onmouseover="this.src='Givenchy/GVBack1080.png'" onmouseout="this.src='Givenchy/GVFront1080.png'">
+            <img class="img-thumbnail" src="Givenchy/GVFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-7">
-            <img class="img-thumbnail" src="Givenchy/GVFrontLg.png" onmouseover="this.src='Givenchy/GVBackLg.png'" onmouseout="this.src='Givenchy/GVFrontLg.png'">
+            <img class="img-thumbnail" src="Givenchy/GVBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -222,10 +222,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-8">
-            <img class="img-thumbnail" src="RomeoGigli/RG2Front1080.png" onmouseover="this.src='RomeoGigli/RG2Back1080.png'" onmouseout="this.src='RomeoGigli/RG2Front1080.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-8">
-            <img class="img-thumbnail" src="RomeoGigli/RG2FrontLg.png" onmouseover="this.src='RomeoGigli/RG2BackLg.png'" onmouseout="this.src='RomeoGigli/RG2FrontLg.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -239,15 +239,15 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-9">
-            <img class="img-thumbnail" src="Gucci/G3Front1080.png" onmouseover="this.src='Gucci/G3Back1080.png'" onmouseout="this.src='Gucci/G3Front1080.png'">
+            <img class="img-thumbnail" src="Gucci/G3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-9">
-            <img class="img-thumbnail" src="Gucci/G3FrontLg.png" onmouseover="this.src='Gucci/G3BackLg.png'" onmouseout="this.src='Gucci/G3FrontLg.png'">
+            <img class="img-thumbnail" src="Gucci/G3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
           <p class="brandname">Gucci</p>
-          <!-- <p class="itemname">Size 8</p>  -->
+          <p class="itemname">Sold</p> 
         </div> 
       </div>    
     </div>
@@ -256,10 +256,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-10">
-            <img class="img-thumbnail" src="GianfrancoFerre/GF1Front1080.png" onmouseover="this.src='GianfrancoFerre/GF1Back1080.png'" onmouseout="this.src='GianfrancoFerre/GF1Front1080.png'">
+            <img class="img-thumbnail" src="GianfrancoFerre/GF1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-10">
-            <img class="img-thumbnail" src="GianfrancoFerre/GF1FrontLg.png" onmouseover="this.src='GianfrancoFerre/GF1BackLg.png'" onmouseout="this.src='GianfrancoFerre/GF1FrontLg.png'">
+            <img class="img-thumbnail" src="GianfrancoFerre/GF1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -273,10 +273,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-11">
-            <img class="img-thumbnail" src="YvesSaintLaurent/YSL11Front1080.png" onmouseover="this.src='YvesSaintLaurent/YSL11Back1080.png'" onmouseout="this.src='YvesSaintLaurent/YSL11Front1080.png'">
+            <img class="img-thumbnail" src="YvesSaintLaurent/YSL11Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-11">
-            <img class="img-thumbnail" src="YvesSaintLaurent/YSL11FrontLg.png" onmouseover="this.src='YvesSaintLaurent/YSL11BackLg.png'" onmouseout="this.src='YvesSaintLaurent/YSL11FrontLg.png'">
+            <img class="img-thumbnail" src="YvesSaintLaurent/YSL11BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -290,10 +290,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-12">
-            <img class="img-thumbnail" src="Valentino/V2Front1080.png" onmouseover="this.src='Valentino/V2Back1080.png'" onmouseout="this.src='Valentino/V2Front1080.png'">
+            <img class="img-thumbnail" src="Valentino/V2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-12">
-            <img class="img-thumbnail" src="Valentino/V2FrontLg.png" onmouseover="this.src='Valentino/V2BackLg.png'" onmouseout="this.src='Valentino/V2FrontLg.png'">
+            <img class="img-thumbnail" src="Valentino/V2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -307,14 +307,14 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-13">
-            <img class="img-thumbnail" src="WayneClark/WCFront1080.png" onmouseover="this.src='WayneClark/WCBack1080.png'" onmouseout="this.src='WayneClark/WCFront1080.png'">
+            <img class="img-thumbnail" src="WayneClark/WCFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-13">
-            <img class="img-thumbnail" src="WayneClark/WCFrontLg.png" onmouseover="this.src='WayneClark/WCBackLg.png'" onmouseout="this.src='WayneClark/WCFrontLg.png'">
+            <img class="img-thumbnail" src="WayneClark/WCBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
-          <p class="brandname">Wayne Clark</p>
+          <p class="brandname">Chloe</p>
           <!-- <p class="itemname">Size 8</p>  -->
         </div> 
       </div>    
@@ -324,10 +324,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-14">
-            <img class="img-thumbnail" src="Montana/MT2Front1080.png" onmouseover="this.src='Montana/MT2Back1080.png'" onmouseout="this.src='Montana/MT2Front1080.png'">
+            <img class="img-thumbnail" src="Montana/MT2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-14">
-            <img class="img-thumbnail" src="Montana/MT2FrontLg.png" onmouseover="this.src='Montana/MT2BackLg.png'" onmouseout="this.src='Montana/MT2FrontLg.png'">
+            <img class="img-thumbnail" src="Montana/MT2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -341,10 +341,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-15">
-            <img class="img-thumbnail" src="RomeoGigli/RG3Front1080.png" onmouseover="this.src='RomeoGigli/RG3Back1080.png'" onmouseout="this.src='RomeoGigli/RG3Front1080.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-15">
-            <img class="img-thumbnail" src="RomeoGigli/RG3FrontLg.png" onmouseover="this.src='RomeoGigli/RG3BackLg.png'" onmouseout="this.src='RomeoGigli/RG3FrontLg.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -358,10 +358,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-16">
-            <img class="img-thumbnail" src="SarahPhillips/SPFront1080.png" onmouseover="this.src='SarahPhillips/SPBack1080.png'" onmouseout="this.src='SarahPhillips/SPFront1080.png'">
+            <img class="img-thumbnail" src="SarahPhillips/SPFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-16">
-            <img class="img-thumbnail" src="SarahPhillips/SPFrontLg.png" onmouseover="this.src='SarahPhillips/SPBackLg.png'" onmouseout="this.src='SarahPhillips/SPFrontLg.png'">
+            <img class="img-thumbnail" src="SarahPhillips/SPBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -375,10 +375,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-17">
-            <img class="img-thumbnail" src="LouisFeraud/LF1Front1080.png" onmouseover="this.src='LouisFeraud/LF1Back1080.png'" onmouseout="this.src='LouisFeraud/LF1Front1080.png'">
+            <img class="img-thumbnail" src="LouisFeraud/LF1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-17">
-            <img class="img-thumbnail" src="LouisFeraud/LF1FrontLg.png" onmouseover="this.src='LouisFeraud/LF1BackLg.png'" onmouseout="this.src='LouisFeraud/LF1FrontLg.png'">
+            <img class="img-thumbnail" src="LouisFeraud/LF1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -392,10 +392,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-18">
-            <img class="img-thumbnail" src="EmanuelUngaro/EU2Front1080.png" onmouseover="this.src='EmanuelUngaro/EU2Back1080.png'" onmouseout="this.src='EmanuelUngaro/EU2Front1080.png'">
+            <img class="img-thumbnail" src="EmanuelUngaro/EU2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-18">
-            <img class="img-thumbnail" src="EmanuelUngaro/EU2FrontLg.png" onmouseover="this.src='EmanuelUngaro/EU2BackLg.png'" onmouseout="this.src='EmanuelUngaro/EU2FrontLg.png'">
+            <img class="img-thumbnail" src="EmanuelUngaro/EU2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -409,10 +409,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-19">
-            <img class="img-thumbnail" src="Gucci/G4Front1080.png" onmouseover="this.src='Gucci/G3Back1080.png'" onmouseout="this.src='Gucci/G4Front1080.png'">
+            <img class="img-thumbnail" src="Gucci/G4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-19">
-            <img class="img-thumbnail" src="Gucci/G4FrontLg.png" onmouseover="this.src='Gucci/G3BackLg.png'" onmouseout="this.src='Gucci/G4FrontLg.png'">
+            <img class="img-thumbnail" src="Gucci/G3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -426,10 +426,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-20">
-            <img class="img-thumbnail" src="Escada/E2Front1080.png" onmouseover="this.src='Escada/E2Back1080.png'" onmouseout="this.src='Escada/E2Front1080.png'">
+            <img class="img-thumbnail" src="Escada/E2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-20">
-            <img class="img-thumbnail" src="Escada/E2FrontLg.png" onmouseover="this.src='Escada/E2BackLg.png'" onmouseout="this.src='Escada/E2FrontLg.png'">
+            <img class="img-thumbnail" src="Escada/E2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -443,15 +443,15 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-21">
-            <img class="img-thumbnail" src="RomeoGigli/RG4Front1080.png" onmouseover="this.src='RomeoGigli/RG4Back1080.png'" onmouseout="this.src='RomeoGigli/RG4Front1080.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-21">
-            <img class="img-thumbnail" src="RomeoGigli/RG4FrontLg.png" onmouseover="this.src='RomeoGigli/RG4BackLg.png'" onmouseout="this.src='RomeoGigli/RG4FrontLg.png'">
+            <img class="img-thumbnail" src="RomeoGigli/RG4BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
           <p class="brandname">Romeo Gigli</p>
-          <!-- <p class="itemname">Size 8</p>  -->
+          <p class="itemname">Sold</p> 
         </div> 
       </div>    
     </div>
@@ -460,10 +460,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-22">
-            <img class="img-thumbnail" src="EmanuelUngaro/EU3Front1080.png" onmouseover="this.src='EmanuelUngaro/EU3Back1080.png'" onmouseout="this.src='EmanuelUngaro/EU3Front1080.png'">
+            <img class="img-thumbnail" src="EmanuelUngaro/EU3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-22">
-            <img class="img-thumbnail" src="EmanuelUngaro/EU3FrontLg.png" onmouseover="this.src='EmanuelUngaro/EU3BackLg.png'" onmouseout="this.src='EmanuelUngaro/EU3FrontLg.png'">
+            <img class="img-thumbnail" src="EmanuelUngaro/EU3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -477,10 +477,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-23">
-            <img class="img-thumbnail" src="Valentino/V3Front1080.png" onmouseover="this.src='Valentino/V3Back1080.png'" onmouseout="this.src='Valentino/V3Front1080.png'">
+            <img class="img-thumbnail" src="Valentino/V3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-23">
-            <img class="img-thumbnail" src="Valentino/V3FrontLg.png" onmouseover="this.src='Valentino/V3BackLg.png'" onmouseout="this.src='Valentino/V3FrontLg.png'">
+            <img class="img-thumbnail" src="Valentino/V3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -494,10 +494,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-24">
-            <img class="img-thumbnail" src="JacquesFath/JF4Front1080.png" onmouseover="this.src='JacquesFath/JF4Back1080.png'" onmouseout="this.src='JacquesFath/JF4Front1080.png'">
+            <img class="img-thumbnail" src="JacquesFath/JF4Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-24">
-            <img class="img-thumbnail" src="JacquesFath/JF4FrontLg.png" onmouseover="this.src='JacquesFath/JF4BackLg.png'" onmouseout="this.src='JacquesFath/JF4FrontLg.png'">
+            <img class="img-thumbnail" src="JacquesFath/JF4BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -511,10 +511,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-25">
-            <img class="img-thumbnail" src="OscardelaRenta/OD9Front1080.png" onmouseover="this.src='OscardelaRenta/OD9Back1080.png'" onmouseout="this.src='OscardelaRenta/OD9Front1080.png'">
+            <img class="img-thumbnail" src="OD9Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-25">
-            <img class="img-thumbnail" src="OscardelaRenta/OD9FrontLg.png" onmouseover="this.src='OscardelaRenta/OD9BackLg.png'" onmouseout="this.src='OscardelaRenta/OD9FrontLg.png'">
+            <img class="img-thumbnail" src="OD9BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -528,10 +528,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-26">
-            <img class="img-thumbnail" src="OscardelaRenta/OD10Front1080.png" onmouseover="this.src='OscardelaRenta/OD10Back1080.png'" onmouseout="this.src='OscardelaRenta/OD10Front1080.png'">
+            <img class="img-thumbnail" src="OD10Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-26">
-            <img class="img-thumbnail" src="OscardelaRenta/OD10FrontBlkLg.png" onmouseover="this.src='OscardelaRenta/OD10BackBlkLg.png'" onmouseout="this.src='OscardelaRenta/OD10FrontBlkLg.png'">
+            <img class="img-thumbnail" src="OD10BackBlkLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -545,10 +545,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-27">
-            <img class="img-thumbnail" src="RitmodiPerla/RPFront1080.png" onmouseover="this.src='RitmodiPerla/RPBack1080.png'" onmouseout="this.src='RitmodiPerla/RPFront1080.png'">
+            <img class="img-thumbnail" src="RitmodiPerla/RPFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-27">
-            <img class="img-thumbnail" src="RitmodiPerla/RPFrontBlkLg.png" onmouseover="this.src='RitmodiPerla/RPBackBlkLg.png'" onmouseout="this.src='RitmodiPerla/RPFrontBlkLg.png'">
+            <img class="img-thumbnail" src="RitmodiPerla/RPBackBlkLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -562,10 +562,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-28">
-            <img class="img-thumbnail" src="Zoran/ZFront1080.png" onmouseover="this.src='Zoran/ZBack1080.png'" onmouseout="this.src='Zoran/ZFront1080.png'">
+            <img class="img-thumbnail" src="Zoran/ZFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-28">
-            <img class="img-thumbnail" src="Zoran/ZFrontBlkLg.png" onmouseover="this.src='Zoran/ZBackBlkLg.png'" onmouseout="this.src='Zoran/ZFrontBlkLg.png'">
+            <img class="img-thumbnail" src="Zoran/ZBackBlkLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -579,10 +579,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-29">
-            <img class="img-thumbnail" src="JacquelinedeRibes/JRFront1080.png" onmouseover="this.src='JacquelinedeRibes/JRBack1080.png'" onmouseout="this.src='JacquelinedeRibes/JRFront1080.png'">
+            <img class="img-thumbnail" src="JacquelinedeRibes/JRFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-29">
-            <img class="img-thumbnail" src="JacquelinedeRibes/JRFrontLg.png" onmouseover="this.src='JacquelinedeRibes/JRBackLg.png'" onmouseout="this.src='JacquelinedeRibes/JRFrontLg.png'">
+            <img class="img-thumbnail" src="JacquelinedeRibes/JRBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -596,10 +596,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-30">
-            <img class="img-thumbnail" src="JonquilByDianeSamandi/JDSFront1080.png" onmouseover="this.src='JonquilByDianeSamandi/JDSBack1080.png'" onmouseout="this.src='JonquilByDianeSamandi/JDSFront1080.png'">
+            <img class="img-thumbnail" src="JonquilByDianeSamandi/JDSFront1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-30">
-            <img class="img-thumbnail" src="JonquilByDianeSamandi/JDSFrontLg.png" onmouseover="this.src='JonquilByDianeSamandi/JDSBackLg.png'" onmouseout="this.src='JonquilByDianeSamandi/JDSFrontLg.png'">
+            <img class="img-thumbnail" src="JonquilByDianeSamandi/JDSBackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -613,10 +613,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-31">
-            <img class="img-thumbnail" src="Moschino/M1Front1080.png" onmouseover="this.src='Moschino/M1Back1080.png'" onmouseout="this.src='Moschino/M1Front1080.png'">
+            <img class="img-thumbnail" src="Moschino/M1Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-31">
-            <img class="img-thumbnail" src="Moschino/M1FrontLg.png" onmouseover="this.src='Moschino/M1BackLg.png'" onmouseout="this.src='Moschino/M1FrontLg.png'">
+            <img class="img-thumbnail" src="Moschino/M1BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -630,10 +630,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-32">
-            <img class="img-thumbnail" src="Moschino/M2Front1080.png" onmouseover="this.src='Moschino/M2Back1080.png'" onmouseout="this.src='Moschino/M2Front1080.png'">
+            <img class="img-thumbnail" src="Moschino/M2Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-32">
-            <img class="img-thumbnail" src="Moschino/M2FrontLg.png" onmouseover="this.src='Moschino/M2BackLg.png'" onmouseout="this.src='Moschino/M2FrontLg.png'">
+            <img class="img-thumbnail" src="Moschino/M2BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">
@@ -647,10 +647,10 @@
     <div class="col-lg-4 col-sm-6 mt-5 mt-sm-0">
       <div class="lb-album">
           <a href="#top-33">
-            <img class="img-thumbnail" src="Moschino/M3Front1080.png" onmouseover="this.src='Moschino/M3Back1080.png'" onmouseout="this.src='Moschino/M3Front1080.png'">
+            <img class="img-thumbnail" src="Moschino/M3Front1080.png">
           </a>
           <div class="lb-overlay d-none d-sm-block" id="top-33">
-            <img class="img-thumbnail" src="Moschino/M3FrontLg.png" onmouseover="this.src='Moschino/M3BackLg.png'" onmouseout="this.src='Moschino/M3FrontLg.png'">
+            <img class="img-thumbnail" src="Moschino/M3BackLg.png">
             <a href="#page" class="lb-close">Close</a>
           </div>  
         <div class="description">


### PR DESCRIPTION
Images were loading and crashing. What I did was remove mouseover effects and enabled the "click to view" images to be only the back view of garments. This way we progressed our momentum of launching the site and can revisit the goal view of mouseover effects and "click to view" to be a zoomed or larger in the image once a "lazy load" effect is applied. Funny enough, the shoes page has the most images of all the pages yet loads effortlessly and functions properly with mouseover effects and such.